### PR TITLE
Drop support for external databases and i386

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ postgres.env
 config/
 data/
 .envrc
+*.ppm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ARG BASE_IMAGE=ubuntu:20.04
 ARG BUILD_ENV=cached
 
-FROM ${BASE_IMAGE} as build_cached
 # TODO i386 support
-ONBUILD COPY ./ManageEngine_PMP_64bit.bin /tmp/pmp_installer.bin
+# FROM ${BASE_IMAGE} as build_cached
+# ONBUILD COPY ./ManageEngine_PMP_64bit.bin /tmp/pmp_installer.bin
 
 FROM ${BASE_IMAGE} as build_no_cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG BUILD_ENV=cached
 
-# TODO i386 support
-# FROM ${BASE_IMAGE} as build_cached
-# ONBUILD COPY ./ManageEngine_PMP_64bit.bin /tmp/pmp_installer.bin
-
-FROM ${BASE_IMAGE} as build_no_cache
-
-FROM build_${BUILD_ENV}
+FROM ${BASE_IMAGE}
 
 ARG PMP_HOME=/srv/pmp
 ARG PMP_VERSION=10404
 
-ENV PMP_VERSION=${PMP_VERSION} \
-    PMP_HOME=${PMP_HOME} \
+ENV PMP_VERSION=$PMP_VERSION \
+    PMP_HOME=$PMP_HOME \
     SERVER_STATE=master \
     TIMEOUT_DB=60 \
     TIMEOUT_PMP=300 \
@@ -21,12 +14,11 @@ ENV PMP_VERSION=${PMP_VERSION} \
 
 COPY pmp.properties /tmp/pmp.properties
 COPY entrypoint.sh /entrypoint.sh
-
 COPY install.sh /install.sh
 
-RUN bash /install.sh && rm -f /install.sh
+RUN bash -x /install.sh "$PMP_VERSION" && rm -f /install.sh
 
-WORKDIR /data
+WORKDIR /data/pmp
 
 # https://www.manageengine.com/products/passwordmanagerpro/help/installation.html#Ports
 EXPOSE 5522/tcp 7070/tcp 7272/tcp 7273/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:20.04
+ARG BUILD_ENV=cached
+
+FROM ${BASE_IMAGE} as build_cached
+# TODO i386 support
+ONBUILD COPY ./ManageEngine_PMP_64bit.bin /tmp/pmp_installer.bin
+
+FROM ${BASE_IMAGE} as build_no_cache
+
+FROM build_${BUILD_ENV}
 
 ARG PMP_HOME=/srv/pmp
+ARG PMP_VERSION=10404
 
-ENV PMP_HOME=${PMP_HOME} \
+ENV PMP_VERSION=${PMP_VERSION} \
+    PMP_HOME=${PMP_HOME} \
     SERVER_STATE=master \
     TIMEOUT_DB=60 \
     TIMEOUT_PMP=300 \
@@ -11,69 +22,17 @@ ENV PMP_HOME=${PMP_HOME} \
 COPY pmp.properties /tmp/pmp.properties
 COPY entrypoint.sh /entrypoint.sh
 
-# ADD ./ManageEngine_PMP_64bit.bin /tmp/pmp_installer.bin
+COPY install.sh /install.sh
 
-RUN apt-get update && \
-    apt-get install -y curl unzip && \
-    curl -fsSL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
-      -o /usr/bin/wait-for-it.sh && \
-    if [ "$(dpkg --print-architecture)" = "i386" ]; \
-    then \
-      install_bin=ManageEngine_PMP.bin; \
-    else \
-      install_bin=ManageEngine_PMP_64bit.bin; \
-    fi && \
-    echo "Grabbing md5 checksum from manageengine.com" && \
-    curl -fsSL "https://www.manageengine.com/products/passwordmanagerpro/download.html" | \
-      sed -n '/<!--PMP MD5SUM-->/,/<!--PMP MD5SUM-->/p;' | \
-      sed -rn "/$install_bin/s/.*[<>]([^><]{32})[<>].+/\1/p" | \
-      tr -d '\n' > /tmp/pmp_installer.bin.md5sum && \
-    echo " /tmp/pmp_installer.bin" >> /tmp/pmp_installer.bin.md5sum && \
-    cat /tmp/pmp_installer.bin.md5sum && \
-    url="https://www.manageengine.com/products/passwordmanagerpro/8621641/${install_bin}" && \
-    echo "Downloading PMP installer from $url" && \
-    curl -fsSL -o /tmp/pmp_installer.bin "$url" && \
-    md5sum -c /tmp/pmp_installer.bin.md5sum && \
-    chmod +x /tmp/pmp_installer.bin /usr/bin/wait-for-it.sh && \
-    # Update PMP_HOME in properties
-    sed -i "s|/srv/pmp|${PMP_HOME}|" /tmp/pmp.properties && \
-    /tmp/pmp_installer.bin -i silent -f /tmp/pmp.properties && \
-    # If PMP_HOME does not end with a PMP dir then it get installed
-    # in PMP_HOME/PMP
-    if [ "$(basename $PMP_HOME)" != "PMP" ]; \
-    then \
-      mv "${PMP_HOME}/PMP" "/tmp/pmp.tmp" && \
-      mv "${PMP_HOME}" "/tmp/pmp_deleteme" && \
-      rmdir "/tmp/pmp_deleteme" && \
-      mv "/tmp/pmp.tmp" "${PMP_HOME}"; \
-    fi && \
-    rm -rf "${PMP_HOME}/logs" && \
-    mkdir -p /data/logs /data/backups && \
-    ln -sf /data/logs "${PMP_HOME}/logs" && \
-    ln -sf /data/backups "${PMP_HOME}/Backup" && \
-    cd "${PMP_HOME}/bin" && \
-    bash pmp.sh install | grep "installed successfully" && \
-    # Save original config and symlink the conf dir
-    mv "${PMP_HOME}/conf" "${PMP_HOME}/conf.orig" && \
-    ln -sf /config "${PMP_HOME}/conf" && \
-    # Do the same for PMP_HOME/lib (for license persistence)
-    mv "${PMP_HOME}/lib" "${PMP_HOME}/lib.orig" && \
-    ln -sf /data/lib "${PMP_HOME}/lib" && \
-    # Cleanup
-    rm -rf \
-      /var/lib/apt/lists/* \
-      /tmp/pmp_installer.bin \
-      /tmp/pmp_installer.bin.md5sum \
-      /tmp/pmp.properties
+RUN bash /install.sh && rm -f /install.sh
 
-WORKDIR ${PMP_HOME}
+WORKDIR /data
 
 # https://www.manageengine.com/products/passwordmanagerpro/help/installation.html#Ports
 EXPOSE 5522/tcp 7070/tcp 7272/tcp 7273/tcp
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-VOLUME ["/config"]
 VOLUME ["/data"]
 
-HEALTHCHECK --start-period=5m CMD curl -qskL https://localhost:7272 || exit 1
+HEALTHCHECK --start-period=5m CMD curl -fqskL https://localhost:7272

--- a/buildx.sh
+++ b/buildx.sh
@@ -56,9 +56,17 @@ else
   LATEST=1
 fi
 
+if [[ -z "$version" ]]
+then
+  echo "Failed to determine version" >&2
+  exit 6
+fi
+
+EXTRA_BUILD_ARGS+=("--build-arg" "PMP_VERSION=${version}")
+
 if [[ "$GITHUB_ACTIONS" == "true" ]] || [[ -n "$NO_CACHE" ]]
 then
-  EXTRA_BUILD_ARGS+=("--no-cache" "--build-arg=build_env=no_cache")
+  EXTRA_BUILD_ARGS+=("--no-cache")
 fi
 
 if [[ -n "$PUSH" ]]
@@ -73,16 +81,11 @@ then
   EXTRA_BUILD_ARGS+=(-t "${IMAGE}:latest")
 fi
 
-if [[ -z "$version" ]]
-then
-  echo "Failed to determine version" >&2
-  exit 6
-fi
-
 echo "Building image for PMP version $version"
 
 # TODO linux/386 support
 docker buildx build \
+  --progress plain \
   --platform "linux/amd64" \
   "${EXTRA_BUILD_ARGS[@]}" \
   -t "${IMAGE}:${version}" \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 services:
   pmp:
     build: .
-    image: postlu/pmp
+    image: postlu/pmp:latest
     restart: unless-stopped
     container_name: pmp
     hostname: pmp
@@ -12,22 +12,9 @@ services:
       - "7070:7070"
       - "7272:7272"
       - "7273:7273"
-    env_file:
-      - postgres.env
+    # environment:
+    #   - PMP_UPGRADE=1
     volumes:
-      - ./config/pmp:/config
       - ./data/pmp:/data
       # DEVEL
-      - ./entrypoint.sh:/entrypoint.sh
-
-  database:
-    # The PMP appliance ships with psql 9.5
-    # image: postgres:9.5
-    image: postgres:12
-    #command: -c ssl=on -c ssl_cert_file=/var/lib/postgresql/wildcard.dt.ept.lu.crt -c ssl_key_file=/var/lib/postgresql/wildcard.dt.ept.lu.key
-    restart: unless-stopped
-    container_name: pmp-db
-    volumes:
-      - ./data/database:/var/lib/postgresql/data
-    env_file:
-      - postgres.env
+      # - ./entrypoint.sh:/entrypoint.sh

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 set -euxo
 
+PMP_VERSION="$1"
 PMP_TMP_HOME="${PMP_HOME}.orig"
 PMP_INSTALLER="/tmp/pmp_installer.bin"
 
@@ -12,7 +13,7 @@ install_dependencies() {
   curl -fsSL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
     -o /usr/bin/wait-for-it.sh
 
-  chmod +x "${PMP_INSTALLER}" /usr/bin/wait-for-it.sh
+  chmod +x /usr/bin/wait-for-it.sh
 }
 
 cleanup() {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euxo
+
+PMP_TMP_HOME="${PMP_HOME}.orig"
+PMP_INSTALLER="/tmp/pmp_installer.bin"
+
+install_dependencies() {
+  apt-get update
+  apt-get install -y curl unzip
+
+  curl -fsSL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
+    -o /usr/bin/wait-for-it.sh
+
+  chmod +x "${PMP_INSTALLER}" /usr/bin/wait-for-it.sh
+}
+
+cleanup() {
+  rm -rf \
+    /var/lib/apt/lists/* \
+    "${PMP_INSTALLER}" \
+    /tmp/pmp.properties
+}
+
+install_pmp() {
+  if [[ -e "${PMP_INSTALLER}" ]]
+  then
+    echo "Using the local install binary at ${PMP_INSTALLER}"
+  else
+    if [[ "$(dpkg --print-architecture)" == "i386" ]]
+    then
+      install_bin=ManageEngine_PMP.bin
+    else
+      install_bin=ManageEngine_PMP_64bit.bin
+    fi
+
+    url="https://archives2.manageengine.com/passwordmanagerpro/${PMP_VERSION}/${install_bin}"
+    echo "Downloading PMP installer from $url"
+    curl -fsSL -o "${PMP_INSTALLER}" "$url"
+  fi
+
+  chmod +x "${PMP_INSTALLER}"
+
+  # Update PMP_HOME in properties (/srv/pmp was used as install path at the
+  # time of creation of the .properties file)
+  sed -i "s|/srv/pmp|${PMP_HOME}|" /tmp/pmp.properties
+  "${PMP_INSTALLER}" -i silent -f /tmp/pmp.properties
+  fix_pmp_home
+
+  cd "${PMP_HOME}/bin"  # yup. That's required by pmp.sh 🤦
+  bash "${PMP_HOME}/bin/pmp.sh" install | grep "installed successfully"
+}
+
+fix_pmp_home() {
+  # If PMP_HOME does not end with a PMP dir then it get installed
+  # in PMP_HOME/PMP
+  if [[ "$(basename "$PMP_HOME")" != "PMP" ]]
+  then
+    mv "${PMP_HOME}/PMP" "/tmp/pmp.tmp"
+    mv "${PMP_HOME}" "/tmp/pmp_deleteme"
+    rmdir "/tmp/pmp_deleteme"
+    mv "/tmp/pmp.tmp" "${PMP_HOME}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+  echo "Building container for PMP ${PMP_VERSION}"
+  install_dependencies
+  install_pmp
+  cleanup
+
+  # Move PMP_HOME to PMP_HOME.orig (will be copied over to /data at runtime)
+  mv "$PMP_HOME" "$PMP_TMP_HOME"
+fi


### PR DESCRIPTION
This effectively removes support for i386 and external databases.

But why?

- i386: I rebased on ubuntu:20.04 and there are no i386 images available anymore for Ubuntu. Arguably no one is using i386 in 2020.
- external database: According to the ManageEngine support team upgrades are not well supported when using an external DB. This allows us to get rid of whole lot of weird hacks to make it (ext PG DBs) work in the first place.